### PR TITLE
feat(integrity): calculate dm verity root hash for image

### DIFF
--- a/pkg/integrity/dmverity.go
+++ b/pkg/integrity/dmverity.go
@@ -34,6 +34,7 @@ func GetRootHashAnnotationsForImage(ctx context.Context, img v1.Image) (map[stri
 
 	return map[string]string{
 		annoNameDMVerityRootHash: rootHash,
+		annoNameBuildTimestamp:   staticMkfsBuildTimestamp,
 	}, nil
 }
 

--- a/pkg/integrity/dmverity.go
+++ b/pkg/integrity/dmverity.go
@@ -57,7 +57,7 @@ func CalculateImageDMVerityRootHash(ctx context.Context, img v1.Image) (string, 
 func CalculateLayerDMVerityRootHash(ctx context.Context, layer v1.Layer) (string, error) {
 	rc, err := layer.Uncompressed()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get uncompressed layer: %w", err)
 	}
 	defer rc.Close()
 

--- a/pkg/integrity/dmverity.go
+++ b/pkg/integrity/dmverity.go
@@ -23,6 +23,20 @@ const (
 	magicVeritySalt          = "dc0f616e4bf75776061d5ffb7a6f45e1313b7cc86f3aa49b68de4f6d187bad2b"
 )
 
+func AnnotateImageWithDMVerityRootHash(ctx context.Context, img v1.Image) (v1.Image, error) {
+	rc := mutate.Extract(img)
+	defer rc.Close()
+
+	rootHash, err := CalculateDMVerityRootHash(ctx, rc)
+	if err != nil {
+		return nil, err
+	}
+
+	return mutate.Annotations(img, map[string]string{
+		annoNameDMVerityRootHash: rootHash,
+	}).(v1.Image), nil
+}
+
 func AnnotateLayerWithDMVerityRootHash(ctx context.Context, layer v1.Layer) (mutate.Addendum, error) {
 	rc, err := layer.Uncompressed()
 	if err != nil {

--- a/pkg/integrity/dmverity.go
+++ b/pkg/integrity/dmverity.go
@@ -23,7 +23,7 @@ const (
 	magicVeritySalt          = "dc0f616e4bf75776061d5ffb7a6f45e1313b7cc86f3aa49b68de4f6d187bad2b"
 )
 
-func AnnotateImageWithDMVerityRootHash(ctx context.Context, img v1.Image) (v1.Image, error) {
+func GetRootHashAnnotationsForImage(ctx context.Context, img v1.Image) (map[string]string, error) {
 	rc := mutate.Extract(img)
 	defer rc.Close()
 
@@ -32,9 +32,9 @@ func AnnotateImageWithDMVerityRootHash(ctx context.Context, img v1.Image) (v1.Im
 		return nil, err
 	}
 
-	return mutate.Annotations(img, map[string]string{
+	return map[string]string{
 		annoNameDMVerityRootHash: rootHash,
-	}).(v1.Image), nil
+	}, nil
 }
 
 func AnnotateLayerWithDMVerityRootHash(ctx context.Context, layer v1.Layer) (mutate.Addendum, error) {


### PR DESCRIPTION
It adds ```GetRootHashAnnotationsForImage``` to get roothash of the entire image